### PR TITLE
add ids to advocate seed data

### DIFF
--- a/src/db/seed/advocates.ts
+++ b/src/db/seed/advocates.ts
@@ -1,6 +1,3 @@
-import db from "..";
-import { advocates } from "../schema";
-
 const specialties = [
   "Bipolar",
   "LGBTQ",
@@ -39,6 +36,7 @@ const randomSpecialty = () => {
 
 const advocateData = [
   {
+    id: 1,
     firstName: "John",
     lastName: "Doe",
     city: "New York",
@@ -48,6 +46,7 @@ const advocateData = [
     phoneNumber: 5551234567,
   },
   {
+    id: 2,
     firstName: "Jane",
     lastName: "Smith",
     city: "Los Angeles",
@@ -57,6 +56,7 @@ const advocateData = [
     phoneNumber: 5559876543,
   },
   {
+    id: 3,
     firstName: "Alice",
     lastName: "Johnson",
     city: "Chicago",
@@ -66,6 +66,7 @@ const advocateData = [
     phoneNumber: 5554567890,
   },
   {
+    id: 4,
     firstName: "Michael",
     lastName: "Brown",
     city: "Houston",
@@ -75,6 +76,7 @@ const advocateData = [
     phoneNumber: 5556543210,
   },
   {
+    id: 5,
     firstName: "Emily",
     lastName: "Davis",
     city: "Phoenix",
@@ -84,6 +86,7 @@ const advocateData = [
     phoneNumber: 5553210987,
   },
   {
+    id: 6,
     firstName: "Chris",
     lastName: "Martinez",
     city: "Philadelphia",
@@ -93,6 +96,7 @@ const advocateData = [
     phoneNumber: 5557890123,
   },
   {
+    id: 7,
     firstName: "Jessica",
     lastName: "Taylor",
     city: "San Antonio",
@@ -102,6 +106,7 @@ const advocateData = [
     phoneNumber: 5554561234,
   },
   {
+    id: 8,
     firstName: "David",
     lastName: "Harris",
     city: "San Diego",
@@ -111,6 +116,7 @@ const advocateData = [
     phoneNumber: 5557896543,
   },
   {
+    id: 9,
     firstName: "Laura",
     lastName: "Clark",
     city: "Dallas",
@@ -120,6 +126,7 @@ const advocateData = [
     phoneNumber: 5550123456,
   },
   {
+    id: 10,
     firstName: "Daniel",
     lastName: "Lewis",
     city: "San Jose",
@@ -129,6 +136,7 @@ const advocateData = [
     phoneNumber: 5553217654,
   },
   {
+    id: 11,
     firstName: "Sarah",
     lastName: "Lee",
     city: "Austin",
@@ -138,6 +146,7 @@ const advocateData = [
     phoneNumber: 5551238765,
   },
   {
+    id: 12,
     firstName: "James",
     lastName: "King",
     city: "Jacksonville",
@@ -147,6 +156,7 @@ const advocateData = [
     phoneNumber: 5556540987,
   },
   {
+    id: 13,
     firstName: "Megan",
     lastName: "Green",
     city: "San Francisco",
@@ -156,6 +166,7 @@ const advocateData = [
     phoneNumber: 5559873456,
   },
   {
+    id: 14,
     firstName: "Joshua",
     lastName: "Walker",
     city: "Columbus",
@@ -165,6 +176,7 @@ const advocateData = [
     phoneNumber: 5556781234,
   },
   {
+    id: 15,
     firstName: "Amanda",
     lastName: "Hall",
     city: "Fort Worth",


### PR DESCRIPTION
This pull request updates the advocate seed data to explicitly assign unique `id` values to each advocate entry in the `advocateData` array. This helps ensure deterministic and consistent seeding of advocate records.

Seed data improvements:

* Added explicit `id` fields (values 1–15) to each advocate object in the `advocateData` array in `src/db/seed/advocates.ts` to ensure unique and predictable identifiers for seeded records. [[1]](diffhunk://#diff-301906e6973731f6e506fee2c538515789bc2f3fb605e55f014a9d883a7bd3c6R39) [[2]](diffhunk://#diff-301906e6973731f6e506fee2c538515789bc2f3fb605e55f014a9d883a7bd3c6R49) [[3]](diffhunk://#diff-301906e6973731f6e506fee2c538515789bc2f3fb605e55f014a9d883a7bd3c6R59) [[4]](diffhunk://#diff-301906e6973731f6e506fee2c538515789bc2f3fb605e55f014a9d883a7bd3c6R69) [[5]](diffhunk://#diff-301906e6973731f6e506fee2c538515789bc2f3fb605e55f014a9d883a7bd3c6R79) [[6]](diffhunk://#diff-301906e6973731f6e506fee2c538515789bc2f3fb605e55f014a9d883a7bd3c6R89) [[7]](diffhunk://#diff-301906e6973731f6e506fee2c538515789bc2f3fb605e55f014a9d883a7bd3c6R99) [[8]](diffhunk://#diff-301906e6973731f6e506fee2c538515789bc2f3fb605e55f014a9d883a7bd3c6R109) [[9]](diffhunk://#diff-301906e6973731f6e506fee2c538515789bc2f3fb605e55f014a9d883a7bd3c6R119) [[10]](diffhunk://#diff-301906e6973731f6e506fee2c538515789bc2f3fb605e55f014a9d883a7bd3c6R129) [[11]](diffhunk://#diff-301906e6973731f6e506fee2c538515789bc2f3fb605e55f014a9d883a7bd3c6R139) [[12]](diffhunk://#diff-301906e6973731f6e506fee2c538515789bc2f3fb605e55f014a9d883a7bd3c6R149) [[13]](diffhunk://#diff-301906e6973731f6e506fee2c538515789bc2f3fb605e55f014a9d883a7bd3c6R159) [[14]](diffhunk://#diff-301906e6973731f6e506fee2c538515789bc2f3fb605e55f014a9d883a7bd3c6R169) [[15]](diffhunk://#diff-301906e6973731f6e506fee2c538515789bc2f3fb605e55f014a9d883a7bd3c6R179)

Code cleanup:

* Removed unused imports of `db` and `advocates` from `src/db/seed/advocates.ts`.